### PR TITLE
Namespace scope changes to use bitnami legacy repository

### DIFF
--- a/infrastructure/nginx/release.yaml
+++ b/infrastructure/nginx/release.yaml
@@ -24,4 +24,4 @@ spec:
     service:
       type: NodePort
     image:
-      repository: bitnamilegacy/nginx
+      repository: bitnamilegacy/nginx-ingress-controller

--- a/infrastructure/nginx/release.yaml
+++ b/infrastructure/nginx/release.yaml
@@ -23,3 +23,5 @@ spec:
   values:
     service:
       type: NodePort
+    image:
+      repository: bitnamilegacy/nginx

--- a/infrastructure/redis/values.yaml
+++ b/infrastructure/redis/values.yaml
@@ -6,3 +6,5 @@ cluster:
 master:
   persistence:
     enabled: false
+image:
+  repository: bitnamilegacy/redis

--- a/infrastructure/redis/values.yaml
+++ b/infrastructure/redis/values.yaml
@@ -8,3 +8,4 @@ master:
     enabled: false
 image:
   repository: bitnamilegacy/redis
+  tag: latest

--- a/infrastructure/redis/values.yaml
+++ b/infrastructure/redis/values.yaml
@@ -8,4 +8,3 @@ master:
     enabled: false
 image:
   repository: bitnamilegacy/redis
-  tag: latest


### PR DESCRIPTION
Bitnami image reprecation brownout notice : https://hub.docker.com/r/bitnami/nginx/
https://www.chkk.io/blog/bitnami-deprecation