### PR TITLE
Update bitnami images to legacy path

### DIFF
--- a/infrastructure/nginx/release.yaml
+++ b/infrastructure/nginx/release.yaml
@@ -24,4 +24,4 @@ spec:
     service:
       type: NodePort
     image:
-      repository: bitnamilegacy/nginx
+      repository: bitnamilegacy/nginx-ingress-controller

--- a/infrastructure/nginx/release.yaml
+++ b/infrastructure/nginx/release.yaml
@@ -23,3 +23,5 @@ spec:
   values:
     service:
       type: NodePort
+    image:
+      repository: docker.io/bitnamilegacy/nginx

--- a/infrastructure/nginx/release.yaml
+++ b/infrastructure/nginx/release.yaml
@@ -24,4 +24,4 @@ spec:
     service:
       type: NodePort
     image:
-      repository: docker.io/bitnamilegacy/nginx
+      repository: bitnamilegacy/nginx

--- a/infrastructure/redis/values.yaml
+++ b/infrastructure/redis/values.yaml
@@ -6,3 +6,5 @@ cluster:
 master:
   persistence:
     enabled: false
+image:
+  repository: docker.io/bitnamilegacy/nginx

--- a/infrastructure/redis/values.yaml
+++ b/infrastructure/redis/values.yaml
@@ -7,4 +7,4 @@ master:
   persistence:
     enabled: false
 image:
-  repository: docker.io/bitnamilegacy/redis
+  repository: bitnamilegacy/redis

--- a/infrastructure/redis/values.yaml
+++ b/infrastructure/redis/values.yaml
@@ -7,4 +7,4 @@ master:
   persistence:
     enabled: false
 image:
-  repository: docker.io/bitnamilegacy/nginx
+  repository: docker.io/bitnamilegacy/redis


### PR DESCRIPTION
Bitnami image reprecation brownout notice : https://hub.docker.com/r/bitnami/nginx/
https://www.chkk.io/blog/bitnami-deprecation